### PR TITLE
UMich color scheme

### DIFF
--- a/_data/examples/speakers.yml
+++ b/_data/examples/speakers.yml
@@ -10,7 +10,7 @@
   twitter: aaronisbrewing
   slack: acollier
   github: aaaron-collier
-  image_src: /assets/img/speakers/aaaron-collier.jpg
+  image_src: /assets/img/nopics/nopic5.jpg
   image_alt: |
     This is a great description of what the profile photo shows. It is a photo of someone who has eyes, a face, maybe hair, skin of some color, and there may be some gender-y things worth talking about. The emotions and actions are also described.
   keynote: false

--- a/assets/_scss/_homepage.scss
+++ b/assets/_scss/_homepage.scss
@@ -9,7 +9,7 @@
 }
 
 #conferenceInfo {
-  background-color: $princeton-orange;
+  background-color: $accent;
 
   h1 {
     background-color: fade-out($primary-light, .35);
@@ -71,7 +71,7 @@
   height: 100%;
   width: auto;
   object-fit: cover;
-  object-position: top right; 
+  object-position: top right;
 }
 
 /*

--- a/assets/_scss/_homepage.scss
+++ b/assets/_scss/_homepage.scss
@@ -133,16 +133,3 @@
     height: 550px;
   }
 }
-
-// "Welcome to..." section of the home page
-.welcome a {
-  @include link-styles;
-  color: $accent !important;
-
-  &:hover,
-  &:focus,
-  &:active {
-    @include link-styles-states;
-    color: $primary !important;
-  }
-}

--- a/assets/_scss/_sections.scss
+++ b/assets/_scss/_sections.scss
@@ -21,18 +21,13 @@ section:nth-of-type(3n+2) {
   border-top: 2px solid $gray-light;
 }
 
-section:nth-of-type(3n+3) {
+// <a> rules don't have enough specificity w/o `body .content`
+body .content section:nth-of-type(3n+3) {
   background: $section-3-bg;
   color: $section-3-color;
 
   a {
     color: $section-3-link;
-
-    &:hover,
-    &:focus,
-    &:active {
-      color: $section-3-hover;
-    }
   }
 }
 
@@ -56,5 +51,3 @@ section .general-info a {
     }
   }
 }
-
-

--- a/assets/_scss/_variables.scss
+++ b/assets/_scss/_variables.scss
@@ -1,5 +1,5 @@
 $bootstrap-sass-asset-helper: true !default;
-$transparent: transparent !important;
+$transparent: transparent;
 
 //
 // Variables
@@ -7,7 +7,6 @@ $transparent: transparent !important;
 
 //== Colors
 
-$princeton-orange: #e77500;
 $cultured-white: #F5F5F5;
 $white:    #fff !default;
 $gray-100: #f8f9fa !default;
@@ -40,11 +39,11 @@ $gray-lighter:           $gray-200 !default; // #eee
 
 //End of gray setting
 
-$primary:                 #050505;
+$primary:                 #00274c;
 $primary-dark:            darken($primary, 10%) !default;
 $primary-light:           lighten($primary, 10%) !default;
 
-$accent:                  #f3d03e;
+$accent:                  #ffcb05;
 $accent-dark:             darken($accent, 10%) !default;
 $accent-light:            lighten($accent, 10%);
 $accent-darker:           darken($accent, 20%);

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@ title: code4lib 2024
                 {% if site.data.conf.welcome-message %}<p>{{site.data.conf.welcome-message}}</p>{% endif %}
                 {% if site.data.conf.venue.name != nil %}
                 <p>
-                    The conference will take place at <a class="welcome" href="{{site.data.conf.venue.website}}">{{site.data.conf.venue.name}}</a>,
+                    The conference will take place at <a href="{{site.data.conf.venue.website}}">{{site.data.conf.venue.name}}</a>,
                     in {{ site.data.conf.location }}.
                 </p>
                 {% endif %}

--- a/theme.html
+++ b/theme.html
@@ -148,7 +148,7 @@ hero-image: assets/img/theme-images/hero-image.jpg
                     <!-- date -->
                     <div class="col-12 col-sm-12 col-md-12">
                         <div class="talk-box-detail-icon"><span class="glyphicon glyphicon-calendar"></span></div>
-                        <div class="talk-box-detail-value"> <a href=""></a>March 7th</div>
+                        <div class="talk-box-detail-value"> <a href="#">March 7th</a></div>
                     </div>
 
                     <!-- time of day for presentations -->


### PR DESCRIPTION
This PR changes the primary and accent colors for the site to the one's specified in UMich's branding guide.

For testing, I looked at theme.html and theme-secondary-nav.html then ran the Chrome dev tools a11y check on them. The link contrast in the dark background section 3 was bad, I don't think we actually use this style anywhere on the site (?), but I fixed it anyways.