### PR TITLE
FIX / Copy: Correcting my errors on LPC's text

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -9,7 +9,7 @@ location: 'Ann Arbor, Michigan'
 timezone: 'Eastern'
 search: false
 online-only-conference: false
-welcome-message: "This conference is hosted by the <a href='https://www.si.umich.edu/'>University of Michigan School of Information</a> and <a href='https://lib.umich.edu/'>University of Michigan Library</a>."
+welcome-message: 
 
 catchline:
 

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@ title: code4lib 2024
                 {% if site.data.conf.venue.name != nil %}
                 <p>
                     The conference will take place at {{site.data.conf.venue.name}},
-                    in {{ site.data.conf.location }}. It's hosted by the <a href='https://www.si.umich.edu/'>University of Michigan School of Information</a> and <a href='https://lib.umich.edu/'>University of Michigan Library</a>.
+                    in {{ site.data.conf.location }}. It's hosted by the <a href="https://www.si.umich.edu/">University of Michigan School of Information</a> and <a href="https://lib.umich.edu/">University of Michigan Library</a>.
                 </p>
                 {% endif %}
             </div>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@ title: code4lib 2024
 <section class="welcome">
     <div class="container">
         <div class="row section">
-            <div class="col-lg-9 col-md-7 col-xs-12">
+            <div class="col-lg-12 col-md-7 col-xs-12">
                 <h2>Welcome to {{site.data.conf.location}}{% if site.data.conf.catchline %}, {{site.data.conf.catchline}}{% endif %}</h2>
                 {% if site.data.conf.welcome-message %}<p>{{site.data.conf.welcome-message}}</p>{% endif %}
                 {% if site.data.conf.venue.name != nil %}

--- a/index.html
+++ b/index.html
@@ -34,8 +34,8 @@ title: code4lib 2024
                 {% if site.data.conf.welcome-message %}<p>{{site.data.conf.welcome-message}}</p>{% endif %}
                 {% if site.data.conf.venue.name != nil %}
                 <p>
-                    The conference will take place at <a href="{{site.data.conf.venue.website}}">{{site.data.conf.venue.name}}</a>,
-                    in {{ site.data.conf.location }}.
+                    The conference will take place at {{site.data.conf.venue.name}},
+                    in {{ site.data.conf.location }}. It's hosted by the <a href='https://www.si.umich.edu/'>University of Michigan School of Information</a> and <a href='https://lib.umich.edu/'>University of Michigan Library</a>.
                 </p>
                 {% endif %}
             </div>


### PR DESCRIPTION
Thixs conforms text on the front page to LPC's original request. (My error alone.) 
My original idea was to have it in a template variable, but it looks like that would 
require reworking the front page template to get the text LPC wants. So for now it's 
inline, but if reworking the template is a better idea, I'm here for it.
