### PR TITLE
Add Sponsors link to nav menus

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -186,7 +186,7 @@ peri:
 # Sponsors
 ###########
 # If false, hides sponsors link in navigation and footer
-show-sponsors: false
+show-sponsors: true
 # Toggles whether prospectus button displays on homepage and sponsor pages
 sponsor-buttons: true
 # URL to document


### PR DESCRIPTION
This PR should enable a link to Sponsors to appear in the header and footer of the c4l site. 

Ideally, this link should send users to our Prospectus page first as we're not ready for listing Sponsors quite yet, but we'll find out when we merge! 😅 Not the end of the world as long as the site still builds.