### PR TITLE
Added front-page notice about conference schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@ title: code4lib 2024
                     The conference will take place at {{site.data.conf.venue.name}},
                     in {{ site.data.conf.location }}. It's hosted by the <a href="https://www.si.umich.edu/">University of Michigan School of Information</a> and <a href="https://lib.umich.edu/">University of Michigan Library</a>.
                 </p>
+                <p class="alert alert-warning"><strong>Important schedule note:</strong> The main conference will begin on Monday at 1pm with the opening keynote. Tuesday and Wednesday are full conference days, followed by post-conference workshops on Thursday. Decisions about this year's conference schedule were based on venue availabilty. Keep an eye on <a href="/schedule/">the schedule</a> for details as the program is finalized.</p>
                 {% endif %}
             </div>
         </div>


### PR DESCRIPTION
Making sure people know the workshops are at the end and the first day is a half day.